### PR TITLE
feat: create authenticated header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-starter",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-starter",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "dependencies": {
         "@headlessui/react": "^2.1.2",
         "@heroicons/react": "^2.1.5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,11 @@
-import {ReactNode} from "react";
-import type {Metadata} from "next";
-import {getServerSession} from "next-auth";
-import {Footer, Header} from "@/components";
-import {TABS} from "@/constants";
-import {AuthSessionProvider} from "@/providers";
-import {authConfig} from "@/auth/config";
+import { ReactNode } from "react";
+import type { Metadata } from "next";
+import { getServerSession } from "next-auth";
+import { AuthenticatedHeader, AuthWrapper, Footer, Header } from "@/components";
+import { TABS } from "@/constants";
+import { AuthSessionProvider } from "@/providers";
+import { authConfig } from "@/auth/config";
 import "./globals.css";
-import {AuthenticatedHeader} from "@/components/AuthenticatedHeader";
 
 export const metadata: Metadata = {
   title: "PayHive",
@@ -24,9 +23,12 @@ export default async function RootLayout({
       <body>
         <AuthSessionProvider session={session}>
           <div className="flex flex-col h-full w-full">
-            <Header tabs={TABS} dataTestId="header" />
-            <AuthenticatedHeader tabs={TABS} dataTestId="header" />
-            {children}
+            {session ? (
+              <AuthenticatedHeader dataTestId="authenticated-header" />
+            ) : (
+              <Header tabs={TABS} dataTestId="header" />
+            )}
+            <AuthWrapper>{children}</AuthWrapper>
             <Footer isUserSubscribed={false} dataTestId="payhive" />
           </div>
         </AuthSessionProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,12 @@
-import { ReactNode } from "react";
-import type { Metadata } from "next";
-import { getServerSession } from "next-auth";
-import { Footer, Header } from "@/components";
-import { TABS } from "@/constants";
-import { AuthSessionProvider } from "@/providers";
-import { authConfig } from "@/auth/config";
+import {ReactNode} from "react";
+import type {Metadata} from "next";
+import {getServerSession} from "next-auth";
+import {Footer, Header} from "@/components";
+import {TABS} from "@/constants";
+import {AuthSessionProvider} from "@/providers";
+import {authConfig} from "@/auth/config";
 import "./globals.css";
+import {AuthenticatedHeader} from "@/components/AuthenticatedHeader";
 
 export const metadata: Metadata = {
   title: "PayHive",
@@ -24,6 +25,7 @@ export default async function RootLayout({
         <AuthSessionProvider session={session}>
           <div className="flex flex-col h-full w-full">
             <Header tabs={TABS} dataTestId="header" />
+            <AuthenticatedHeader tabs={TABS} dataTestId="header" />
             {children}
             <Footer isUserSubscribed={false} dataTestId="payhive" />
           </div>

--- a/src/auth/config.ts
+++ b/src/auth/config.ts
@@ -1,10 +1,4 @@
-import NextAuth, {
-  Account,
-  AuthOptions,
-  Profile,
-  Session,
-  User,
-} from "next-auth";
+import NextAuth, { Account, AuthOptions, Session, User } from "next-auth";
 import Credentials from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { compare } from "bcrypt";
@@ -15,6 +9,7 @@ import { JWT } from "next-auth/jwt";
 const prisma = new PrismaClient();
 
 export const authConfig: AuthOptions = {
+  debug: true, // Enable NextAuth debug mode
   pages: {
     signIn: "/sign-in",
   },
@@ -27,22 +22,36 @@ export const authConfig: AuthOptions = {
       async authorize(
         credentials: Record<"email" | "password", string> | undefined,
       ) {
-        console.log("Authorizing user with credentials:", credentials);
-        if (!credentials?.email || !credentials?.password) return null;
+        console.log(
+          "🔐 AUTHORIZE: Starting authorization with credentials:",
+          credentials,
+        );
+        if (!credentials?.email || !credentials?.password) {
+          console.log("❌ AUTHORIZE: Missing credentials");
+          return null;
+        }
 
         const user = await getUser(credentials.email);
-        console.log("User fetched from database:", user);
-        if (!user) return null;
+        console.log("👤 AUTHORIZE: User fetched from database:", user);
+        if (!user) {
+          console.log("❌ AUTHORIZE: User not found");
+          return null;
+        }
 
         const passwordsMatch = await compare(
           credentials.password,
           user.password!,
         );
-        console.log("Passwords match:", passwordsMatch);
+        console.log("🔑 AUTHORIZE: Passwords match:", passwordsMatch);
         if (passwordsMatch) {
           const { password: _, ...userWithoutPassword } = user;
+          console.log(
+            "✅ AUTHORIZE: Success! Returning user:",
+            userWithoutPassword,
+          );
           return userWithoutPassword;
         }
+        console.log("❌ AUTHORIZE: Password mismatch");
         return null;
       },
     }),
@@ -50,9 +59,14 @@ export const authConfig: AuthOptions = {
   adapter: PrismaAdapter(prisma),
   session: {
     strategy: "jwt",
-    maxAge: 60,
+    maxAge: 30 * 24 * 60 * 60, // 30 days
+    updateAge: 24 * 60 * 60, // 24 hours
+  },
+  jwt: {
+    maxAge: 30 * 24 * 60 * 60, // 30 days
   },
   callbacks: {
+    // @ts-ignore
     async jwt({
       token,
       user,
@@ -64,61 +78,98 @@ export const authConfig: AuthOptions = {
       account?: Account | null;
       trigger?: string;
     }) {
-      console.log("JWT callback triggered:", {
-        trigger,
-        hasUser: !!user,
-        hasAccount: !!account,
+      console.log("🎫 JWT CALLBACK START ===========================");
+      console.log("Trigger:", trigger);
+      console.log("Has User:", !!user);
+      console.log("Has Account:", !!account);
+      console.log("Current Time:", Math.floor(Date.now() / 1000));
+      console.log("Token Exp:", token.exp);
+      console.log("Token Contents:", {
+        userId: token.userId,
+        email: token.email,
+        iat: token.iat,
+        exp: token.exp,
+        jti: token.jti,
       });
 
+      // Check if this is a token refresh without user
+      if (!user && !account) {
+        if (token.userId) {
+          console.log("🔄 JWT: Token refresh - keeping existing data");
+          console.log("🔄 JWT: Existing userId:", token.userId);
+          return token;
+        } else {
+          console.log("❌ JWT: Token refresh but NO userId found in token!");
+          console.log("❌ JWT: This token is invalid - clearing it");
+          // Return null to force re-authentication
+          return null;
+        }
+      }
+
+      // New sign in
       if (user) {
-        console.log("User signing in:", user);
+        console.log("🆕 JWT: New sign in - setting user data");
+        console.log("User ID:", user.id);
+        console.log("User Email:", user.email);
         token.userId = user.id;
         token.email = user.email;
       }
 
       if (account) {
-        console.log("Account details:", account);
+        console.log("🔗 JWT: Account data available");
         token.accessToken = account.access_token;
         token.provider = account.provider;
       }
 
+      console.log("🎫 JWT CALLBACK END - Final Token:", {
+        userId: token.userId,
+        email: token.email,
+        exp: token.exp,
+      });
+      console.log("=====================================");
       return token;
     },
+
     async session({ session, token }: { session: Session; token: JWT }) {
-      console.log("Session callback - token:", token);
+      console.log("🏠 SESSION CALLBACK START ===================");
+      console.log("Token:", {
+        userId: token.userId,
+        email: token.email,
+        exp: token.exp,
+        currentTime: Math.floor(Date.now() / 1000),
+      });
+
+      // @ts-ignore
+      const isExpired = token.exp && token.exp < Math.floor(Date.now() / 1000);
+      console.log("Token expired?", isExpired);
 
       if (token && session && session.user) {
-        // @ts-ignore
-        session.user.id = token.userId as string;
-        session.user.email = token.email as string;
+        if (token.userId) {
+          // @ts-ignore
+          session.user.id = token.userId as string;
+          session.user.email = token.email as string;
+          console.log("✅ SESSION: User data set successfully");
+        } else {
+          console.log("❌ SESSION: No userId in token!");
+        }
       }
 
-      console.log("Final session:", session);
+      console.log("🏠 SESSION CALLBACK END - Final Session:", session);
+      console.log("=========================================");
       return session;
     },
   },
+
   events: {
     async signOut({ token, session }: { token: JWT; session: Session }) {
-      console.log("SignOut event triggered");
-      console.log("Token being cleared:", token);
-      console.log("Session being cleared:", session);
+      console.log("🚪 SIGN OUT EVENT");
     },
+
     // @ts-ignore
-    async signIn({
-      user,
-      account,
-      profile,
-    }: {
-      user: User;
-      account: Account;
-      profile: Profile;
-    }) {
-      console.log("SignIn event triggered");
-      console.log("User:", user);
-      console.log("Account:", account.provider);
-    },
-    async session({ session, token }: { session: Session; token: JWT }) {
-      console.log("Session event - session retrieved");
+    async signIn({ user, account }: { user: User; account: Account }) {
+      console.log("🎉 SIGN IN EVENT - User:", user.email);
+      console.log("🎉 SIGN IN EVENT - Provider:", account.provider);
+      return true;
     },
   },
 };

--- a/src/components/AuthWrapper.tsx
+++ b/src/components/AuthWrapper.tsx
@@ -4,6 +4,7 @@ import { useSession } from "next-auth/react";
 import { useParams, usePathname, useRouter } from "next/navigation";
 import { AuthWrapperProps } from "@/types";
 import { PROTECTED_ROUTES } from "@/constants";
+import Loading from "@/components/Loading";
 
 const isProtectedRoute = (pathname: string): boolean =>
   PROTECTED_ROUTES.some(
@@ -19,6 +20,16 @@ export const AuthWrapper = ({
   const router = useRouter();
   const pathName = usePathname();
   const { callbackUrl } = useParams();
+
+  useEffect(() => {
+    console.log("=== AuthWrapper Debug ===");
+    console.log("Status:", status);
+    console.log("Session:", session);
+    console.log("PathName:", pathName);
+    console.log("Document cookies:", document.cookie);
+    console.log("Is protected route:", isProtectedRoute(pathName));
+    console.log("========================");
+  }, [session, status, pathName]);
 
   useEffect(() => {
     if (status === "loading") return;
@@ -38,18 +49,18 @@ export const AuthWrapper = ({
   }, [session, status, router, pathName, requireAuth, redirectTo, callbackUrl]);
 
   if (status === "loading") {
-    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+    return <Loading />;
   }
 
   if (status === "unauthenticated" && isProtectedRoute(pathName)) {
-    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+    return <Loading />;
   }
 
   if (
     status === "authenticated" &&
     (pathName === "/sign-in" || pathName === "/sign-up")
   ) {
-    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+    return <Loading />;
   }
 
   return <>{children}</>;

--- a/src/components/AuthWrapper.tsx
+++ b/src/components/AuthWrapper.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { AuthWrapperProps } from "@/types";
+import { PROTECTED_ROUTES } from "@/constants";
+
+const isProtectedRoute = (pathname: string): boolean =>
+  PROTECTED_ROUTES.some(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+
+export const AuthWrapper = ({
+  children,
+  requireAuth = false,
+  redirectTo = "/sign-in",
+}: AuthWrapperProps) => {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const pathName = usePathname();
+  const { callbackUrl } = useParams();
+
+  useEffect(() => {
+    if (status === "loading") return;
+
+    if (status === "unauthenticated" && isProtectedRoute(pathName)) {
+      const signInUrl = `${redirectTo}?callbackUrl=${encodeURIComponent(pathName)}`;
+      router.push(signInUrl);
+      return;
+    }
+
+    if (
+      status === "authenticated" &&
+      (pathName === "/sign-in" || pathName === "/sign-up")
+    ) {
+      router.push("/profile");
+    }
+  }, [session, status, router, pathName, requireAuth, redirectTo, callbackUrl]);
+
+  if (status === "loading") {
+    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+  }
+
+  if (status === "unauthenticated" && isProtectedRoute(pathName)) {
+    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+  }
+
+  if (
+    status === "authenticated" &&
+    (pathName === "/sign-in" || pathName === "/sign-up")
+  ) {
+    return <div className="pt-44 text-9xl text-green-600">LOADING</div>;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/AuthenticatedHeader.tsx
+++ b/src/components/AuthenticatedHeader.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { FC, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { signOut, useSession } from "next-auth/react";
+import { signOut } from "next-auth/react";
 import { Dialog, DialogPanel } from "@headlessui/react";
 import {
   Bars3Icon,
@@ -9,6 +9,7 @@ import {
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { NavigationTab } from "@/types";
+import { NAVIGATION_TABS } from "@/constants";
 
 export const AuthenticatedHeader: FC<{
   dataTestId: string;
@@ -18,137 +19,7 @@ export const AuthenticatedHeader: FC<{
   const [mobileModalOpen, setMobileModalOpen] = useState<boolean>(false);
   const [mobileModalContent, setMobileModalContent] =
     useState<NavigationTab | null>(null);
-  const { data: session } = useSession();
   const dropdownRef = useRef<HTMLDivElement>(null);
-
-  // Navigation structure
-  const navigationTabs: NavigationTab[] = [
-    {
-      name: "Customers",
-      items: [
-        {
-          name: "Customer List",
-          href: "/customers",
-          description: "View all customers",
-        },
-        {
-          name: "Add Customer",
-          href: "/customers/add",
-          description: "Create new customer",
-        },
-        {
-          name: "Customer Groups",
-          href: "/customers/groups",
-          description: "Manage customer segments",
-        },
-        {
-          name: "Customer Reports",
-          href: "/customers/reports",
-          description: "Customer analytics",
-        },
-      ],
-    },
-    {
-      name: "Banking",
-      items: [
-        {
-          name: "Accounts",
-          href: "/banking/accounts",
-          description: "Bank account management",
-        },
-        {
-          name: "Transactions",
-          href: "/banking/transactions",
-          description: "Transaction history",
-        },
-        {
-          name: "Reconciliation",
-          href: "/banking/reconciliation",
-          description: "Bank reconciliation",
-        },
-        {
-          name: "Transfers",
-          href: "/banking/transfers",
-          description: "Money transfers",
-        },
-      ],
-    },
-    {
-      name: "Accounting",
-      items: [
-        {
-          name: "Chart of Accounts",
-          href: "/accounting/chart",
-          description: "Account structure",
-        },
-        {
-          name: "Journal Entries",
-          href: "/accounting/journal",
-          description: "Manual entries",
-        },
-        {
-          name: "General Ledger",
-          href: "/accounting/ledger",
-          description: "Account balances",
-        },
-        {
-          name: "Trial Balance",
-          href: "/accounting/trial-balance",
-          description: "Balance verification",
-        },
-      ],
-    },
-    {
-      name: "Tools",
-      items: [
-        {
-          name: "Bulk Operations",
-          href: "/tools/bulk",
-          description: "Batch processing",
-        },
-        {
-          name: "Import/Export",
-          href: "/tools/import-export",
-          description: "Data management",
-        },
-        {
-          name: "Integrations",
-          href: "/tools/integrations",
-          description: "Third-party apps",
-        },
-        {
-          name: "Settings",
-          href: "/tools/settings",
-          description: "System configuration",
-        },
-      ],
-    },
-    {
-      name: "Reports",
-      items: [
-        {
-          name: "Financial Reports",
-          href: "/reports/financial",
-          description: "P&L, Balance Sheet",
-        },
-        {
-          name: "Tax Reports",
-          href: "/reports/tax",
-          description: "Tax compliance",
-        },
-        {
-          name: "Custom Reports",
-          href: "/reports/custom",
-          description: "Build your own",
-        },
-        {
-          name: "Scheduled Reports",
-          href: "/reports/scheduled",
-          description: "Automated reporting",
-        },
-      ],
-    },
-  ];
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -208,7 +79,7 @@ export const AuthenticatedHeader: FC<{
                 className="hidden lg:flex lg:gap-x-1 lg:items-center"
                 ref={dropdownRef}
               >
-                {navigationTabs.map((tab) => (
+                {NAVIGATION_TABS.map((tab) => (
                   <div key={tab.name} className="relative font-semibold">
                     <button
                       onClick={() =>
@@ -267,7 +138,6 @@ export const AuthenticatedHeader: FC<{
         </div>
       </header>
 
-      {/* Mobile Menu */}
       <Dialog
         open={mobileMenuOpen}
         onClose={setMobileMenuOpen}
@@ -293,7 +163,7 @@ export const AuthenticatedHeader: FC<{
           <div className="mt-6 flow-root">
             <div className="-my-6 divide-y divide-gray-200">
               <div className="space-y-2 py-6">
-                {navigationTabs.map((tab) => (
+                {NAVIGATION_TABS.map((tab) => (
                   <button
                     key={tab.name}
                     onClick={() => handleMobileTabClick(tab)}
@@ -324,7 +194,6 @@ export const AuthenticatedHeader: FC<{
         </DialogPanel>
       </Dialog>
 
-      {/* Mobile Modal for Dropdown Content */}
       <Dialog
         open={mobileModalOpen}
         onClose={handleMobileModalClose}

--- a/src/components/AuthenticatedHeader.tsx
+++ b/src/components/AuthenticatedHeader.tsx
@@ -1,282 +1,377 @@
 "use client";
-import {FC, useEffect, useRef, useState} from "react";
+import { FC, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import {signOut, useSession} from "next-auth/react";
-import {Dialog, DialogPanel} from "@headlessui/react";
-import {Bars3Icon, ChevronDownIcon, XMarkIcon} from "@heroicons/react/24/outline";
-
-interface DropdownItem {
-    name: string;
-    href: string;
-    description?: string;
-}
-
-interface NavigationTab {
-    name: string;
-    items: DropdownItem[];
-}
+import { signOut, useSession } from "next-auth/react";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import {
+  Bars3Icon,
+  ChevronDownIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { NavigationTab } from "@/types";
 
 export const AuthenticatedHeader: FC<{
-    dataTestId: string;
+  dataTestId: string;
 }> = ({ dataTestId }) => {
-    const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
-    const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
-    const [mobileModalOpen, setMobileModalOpen] = useState<boolean>(false);
-    const [mobileModalContent, setMobileModalContent] = useState<NavigationTab | null>(null);
-    const { data: session } = useSession();
-    const dropdownRef = useRef<HTMLDivElement>(null);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
+  const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+  const [mobileModalOpen, setMobileModalOpen] = useState<boolean>(false);
+  const [mobileModalContent, setMobileModalContent] =
+    useState<NavigationTab | null>(null);
+  const { data: session } = useSession();
+  const dropdownRef = useRef<HTMLDivElement>(null);
 
-    // Navigation structure
-    const navigationTabs: NavigationTab[] = [
+  // Navigation structure
+  const navigationTabs: NavigationTab[] = [
+    {
+      name: "Customers",
+      items: [
         {
-            name: "Customers",
-            items: [
-                { name: "Customer List", href: "/customers", description: "View all customers" },
-                { name: "Add Customer", href: "/customers/add", description: "Create new customer" },
-                { name: "Customer Groups", href: "/customers/groups", description: "Manage customer segments" },
-                { name: "Customer Reports", href: "/customers/reports", description: "Customer analytics" },
-            ],
+          name: "Customer List",
+          href: "/customers",
+          description: "View all customers",
         },
         {
-            name: "Banking",
-            items: [
-                { name: "Accounts", href: "/banking/accounts", description: "Bank account management" },
-                { name: "Transactions", href: "/banking/transactions", description: "Transaction history" },
-                { name: "Reconciliation", href: "/banking/reconciliation", description: "Bank reconciliation" },
-                { name: "Transfers", href: "/banking/transfers", description: "Money transfers" },
-            ],
+          name: "Add Customer",
+          href: "/customers/add",
+          description: "Create new customer",
         },
         {
-            name: "Accounting",
-            items: [
-                { name: "Chart of Accounts", href: "/accounting/chart", description: "Account structure" },
-                { name: "Journal Entries", href: "/accounting/journal", description: "Manual entries" },
-                { name: "General Ledger", href: "/accounting/ledger", description: "Account balances" },
-                { name: "Trial Balance", href: "/accounting/trial-balance", description: "Balance verification" },
-            ],
+          name: "Customer Groups",
+          href: "/customers/groups",
+          description: "Manage customer segments",
         },
         {
-            name: "Tools",
-            items: [
-                { name: "Bulk Operations", href: "/tools/bulk", description: "Batch processing" },
-                { name: "Import/Export", href: "/tools/import-export", description: "Data management" },
-                { name: "Integrations", href: "/tools/integrations", description: "Third-party apps" },
-                { name: "Settings", href: "/tools/settings", description: "System configuration" },
-            ],
+          name: "Customer Reports",
+          href: "/customers/reports",
+          description: "Customer analytics",
+        },
+      ],
+    },
+    {
+      name: "Banking",
+      items: [
+        {
+          name: "Accounts",
+          href: "/banking/accounts",
+          description: "Bank account management",
         },
         {
-            name: "Reports",
-            items: [
-                { name: "Financial Reports", href: "/reports/financial", description: "P&L, Balance Sheet" },
-                { name: "Tax Reports", href: "/reports/tax", description: "Tax compliance" },
-                { name: "Custom Reports", href: "/reports/custom", description: "Build your own" },
-                { name: "Scheduled Reports", href: "/reports/scheduled", description: "Automated reporting" },
-            ],
+          name: "Transactions",
+          href: "/banking/transactions",
+          description: "Transaction history",
         },
-    ];
+        {
+          name: "Reconciliation",
+          href: "/banking/reconciliation",
+          description: "Bank reconciliation",
+        },
+        {
+          name: "Transfers",
+          href: "/banking/transfers",
+          description: "Money transfers",
+        },
+      ],
+    },
+    {
+      name: "Accounting",
+      items: [
+        {
+          name: "Chart of Accounts",
+          href: "/accounting/chart",
+          description: "Account structure",
+        },
+        {
+          name: "Journal Entries",
+          href: "/accounting/journal",
+          description: "Manual entries",
+        },
+        {
+          name: "General Ledger",
+          href: "/accounting/ledger",
+          description: "Account balances",
+        },
+        {
+          name: "Trial Balance",
+          href: "/accounting/trial-balance",
+          description: "Balance verification",
+        },
+      ],
+    },
+    {
+      name: "Tools",
+      items: [
+        {
+          name: "Bulk Operations",
+          href: "/tools/bulk",
+          description: "Batch processing",
+        },
+        {
+          name: "Import/Export",
+          href: "/tools/import-export",
+          description: "Data management",
+        },
+        {
+          name: "Integrations",
+          href: "/tools/integrations",
+          description: "Third-party apps",
+        },
+        {
+          name: "Settings",
+          href: "/tools/settings",
+          description: "System configuration",
+        },
+      ],
+    },
+    {
+      name: "Reports",
+      items: [
+        {
+          name: "Financial Reports",
+          href: "/reports/financial",
+          description: "P&L, Balance Sheet",
+        },
+        {
+          name: "Tax Reports",
+          href: "/reports/tax",
+          description: "Tax compliance",
+        },
+        {
+          name: "Custom Reports",
+          href: "/reports/custom",
+          description: "Build your own",
+        },
+        {
+          name: "Scheduled Reports",
+          href: "/reports/scheduled",
+          description: "Automated reporting",
+        },
+      ],
+    },
+  ];
 
-    useEffect(() => {
-        const handleClickOutside = (event: MouseEvent) => {
-            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-                setActiveDropdown(null);
-            }
-        };
-
-        document.addEventListener("mousedown", handleClickOutside);
-        return () => document.removeEventListener("mousedown", handleClickOutside);
-    }, []);
-
-    const handleMobileTabClick = (tab: NavigationTab) => {
-        setMobileMenuOpen(false);
-        setMobileModalContent(tab);
-        setMobileModalOpen(true);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setActiveDropdown(null);
+      }
     };
 
-    const handleMobileModalClose = () => {
-        setMobileModalOpen(false);
-        setMobileModalContent(null);
-        setMobileMenuOpen(true);
-    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
 
-    return (
-        <>
-            <header
-                className="sticky inset-x-0 top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-200"
-                data-testid={`header-${dataTestId}`}
+  const handleMobileTabClick = (tab: NavigationTab) => {
+    setMobileMenuOpen(false);
+    setMobileModalContent(tab);
+    setMobileModalOpen(true);
+  };
+
+  const handleMobileModalClose = () => {
+    setMobileModalOpen(false);
+    setMobileModalContent(null);
+    setMobileMenuOpen(true);
+  };
+
+  return (
+    <>
+      <header
+        className="sticky inset-x-0 top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-200"
+        data-testid={`header-${dataTestId}`}
+      >
+        <div className="mx-auto max-w-10xl">
+          <div className="px-6 pt-4 pb-4 lg:max-w-none lg:px-8">
+            <nav
+              aria-label="Global"
+              className="flex items-center justify-between"
             >
-                <div className="mx-auto max-w-10xl">
-                    <div className="px-6 pt-4 pb-4 lg:max-w-none lg:px-8">
-                        <nav
-                            aria-label="Global"
-                            className="flex items-center justify-between"
-                        >
-                            <Link href="/" className="-m-1.5 p-2">
-                                <span className="sr-only">PayHive</span>
-                                <span className="text-2xl font-bold text-gray-900">PayHive</span>
-                            </Link>
+              <Link href="/" className="-m-1.5 p-2">
+                <span className="sr-only">PayHive</span>
+                <span className="text-2xl font-bold text-gray-900">
+                  PayHive
+                </span>
+              </Link>
 
-                            <button
-                                type="button"
-                                onClick={() => setMobileMenuOpen(true)}
-                                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors lg:hidden"
-                            >
-                                <span className="sr-only">Open main menu</span>
-                                <Bars3Icon aria-hidden="true" className="size-6" />
-                            </button>
+              <button
+                type="button"
+                onClick={() => setMobileMenuOpen(true)}
+                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors lg:hidden"
+              >
+                <span className="sr-only">Open main menu</span>
+                <Bars3Icon aria-hidden="true" className="size-6" />
+              </button>
 
-                            <div className="hidden lg:flex lg:gap-x-1 lg:items-center" ref={dropdownRef}>
-                                {navigationTabs.map((tab) => (
-                                    <div key={tab.name} className="relative font-semibold">
-                                        <button
-                                            onClick={() => setActiveDropdown(activeDropdown === tab.name ? null : tab.name)}
-                                            className="flex items-center font-semibold gap-1 text-lg text-gray-700 hover:text-green-600 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
-                                        >
-                                            {tab.name}
-                                            <ChevronDownIcon
-                                                className={`size-4 transition-transform ${
-                                                    activeDropdown === tab.name ? 'rotate-180' : ''
-                                                }`}
-                                            />
-                                        </button>
+              <div
+                className="hidden lg:flex lg:gap-x-1 lg:items-center"
+                ref={dropdownRef}
+              >
+                {navigationTabs.map((tab) => (
+                  <div key={tab.name} className="relative font-semibold">
+                    <button
+                      onClick={() =>
+                        setActiveDropdown(
+                          activeDropdown === tab.name ? null : tab.name,
+                        )
+                      }
+                      className="flex items-center font-semibold gap-1 text-lg text-gray-700 hover:text-green-600 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
+                    >
+                      {tab.name}
+                      <ChevronDownIcon
+                        className={`size-4 transition-transform ${
+                          activeDropdown === tab.name ? "rotate-180" : ""
+                        }`}
+                      />
+                    </button>
 
-                                        {activeDropdown === tab.name && (
-                                            <div className="absolute top-full left-0 mt-1 w-72 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
-                                                {tab.items.map((item) => (
-                                                    <Link
-                                                        key={item.name}
-                                                        href={item.href}
-                                                        onClick={() => setActiveDropdown(null)}
-                                                        className="block px-4 py-3 hover:bg-gray-50 transition-colors"
-                                                    >
-                                                        <div className="font-medium text-gray-900">{item.name}</div>
-                                                        {item.description && (
-                                                            <div className="text-sm text-gray-500 mt-1">{item.description}</div>
-                                                        )}
-                                                    </Link>
-                                                ))}
-                                            </div>
-                                        )}
-                                    </div>
-                                ))}
-
-                                <button
-                                    onClick={async () =>
-                                        await signOut({
-                                            redirect: true,
-                                            callbackUrl: "/",
-                                        })
-                                    }
-                                    className="ml-4 font-semibold text-lg text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
-                                >
-                                    Sign Out
-                                </button>
+                    {activeDropdown === tab.name && (
+                      <div className="absolute top-full left-0 mt-1 w-72 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                        {tab.items.map((item) => (
+                          <Link
+                            key={item.name}
+                            href={item.href}
+                            onClick={() => setActiveDropdown(null)}
+                            className="block px-4 py-3 hover:bg-gray-50 transition-colors"
+                          >
+                            <div className="font-medium text-gray-900">
+                              {item.name}
                             </div>
-                        </nav>
-                    </div>
-                </div>
-            </header>
+                            {item.description && (
+                              <div className="text-sm text-gray-500 mt-1">
+                                {item.description}
+                              </div>
+                            )}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
 
-            {/* Mobile Menu */}
-            <Dialog
-                open={mobileMenuOpen}
-                onClose={setMobileMenuOpen}
-                className="lg:hidden"
+                <button
+                  onClick={async () =>
+                    await signOut({
+                      redirect: true,
+                      callbackUrl: "/",
+                    })
+                  }
+                  className="ml-4 font-semibold text-lg text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
+                >
+                  Sign Out
+                </button>
+              </div>
+            </nav>
+          </div>
+        </div>
+      </header>
+
+      {/* Mobile Menu */}
+      <Dialog
+        open={mobileMenuOpen}
+        onClose={setMobileMenuOpen}
+        className="lg:hidden"
+      >
+        <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
+        <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-200 shadow-xl">
+          <div className="flex items-center justify-between">
+            <Link href="/" className="-m-1.5 py-1.5 pr-1.5">
+              <span className="sr-only">PayHive</span>
+              <span className="text-2xl font-bold text-gray-900">PayHive</span>
+            </Link>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen(false)}
+              className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
             >
-                <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
-                <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-200 shadow-xl">
-                    <div className="flex items-center justify-between">
-                        <Link href="/" className="-m-1.5 py-1.5 pr-1.5">
-                            <span className="sr-only">PayHive</span>
-                            <span className="text-2xl font-bold text-gray-900">PayHive</span>
-                        </Link>
-                        <button
-                            type="button"
-                            onClick={() => setMobileMenuOpen(false)}
-                            className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-                        >
-                            <span className="sr-only">Close menu</span>
-                            <XMarkIcon aria-hidden="true" className="size-6" />
-                        </button>
+              <span className="sr-only">Close menu</span>
+              <XMarkIcon aria-hidden="true" className="size-6" />
+            </button>
+          </div>
+
+          <div className="mt-6 flow-root">
+            <div className="-my-6 divide-y divide-gray-200">
+              <div className="space-y-2 py-6">
+                {navigationTabs.map((tab) => (
+                  <button
+                    key={tab.name}
+                    onClick={() => handleMobileTabClick(tab)}
+                    className="flex items-center justify-between w-full -mx-3 rounded-lg px-3 py-3 text-lg font-semibold text-gray-900 hover:bg-gray-50 hover:text-green-600 transition-colors"
+                  >
+                    {tab.name}
+                    <ChevronDownIcon className="size-5 -rotate-90" />
+                  </button>
+                ))}
+              </div>
+
+              <div className="py-6">
+                <button
+                  onClick={async () => {
+                    setMobileMenuOpen(false);
+                    await signOut({
+                      redirect: true,
+                      callbackUrl: "/",
+                    });
+                  }}
+                  className="-mx-3 block rounded-lg px-3 py-3 text-lg font-semibold hover:text-green-600 text-gray-900 hover:bg-gray-50 transition-colors"
+                >
+                  Sign Out
+                </button>
+              </div>
+            </div>
+          </div>
+        </DialogPanel>
+      </Dialog>
+
+      {/* Mobile Modal for Dropdown Content */}
+      <Dialog
+        open={mobileModalOpen}
+        onClose={handleMobileModalClose}
+        className="lg:hidden"
+      >
+        <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
+        <DialogPanel className="fixed inset-0 z-50 overflow-y-auto bg-white">
+          <div className="min-h-full px-6 py-6">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-2xl font-bold text-green-700 ">
+                {mobileModalContent?.name}
+              </h2>
+              <button
+                type="button"
+                onClick={handleMobileModalClose}
+                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+              >
+                <span className="sr-only">Back to menu</span>
+                <XMarkIcon aria-hidden="true" className="size-6" />
+              </button>
+            </div>
+
+            <div className="space-y-1">
+              {mobileModalContent?.items.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  onClick={() => {
+                    setMobileModalOpen(false);
+                    setMobileModalContent(null);
+                  }}
+                  className="group block rounded-lg px-4 py-4 hover:bg-gray-50 transition-colors"
+                >
+                  <div className="font-medium text-gray-900 group-hover:text-green-600 text-lg">
+                    {item.name}
+                  </div>
+                  {item.description && (
+                    <div className="text-sm text-gray-500 mt-1">
+                      {item.description}
                     </div>
-
-                    <div className="mt-6 flow-root">
-                        <div className="-my-6 divide-y divide-gray-200">
-                            <div className="space-y-2 py-6">
-                                {navigationTabs.map((tab) => (
-                                    <button
-                                        key={tab.name}
-                                        onClick={() => handleMobileTabClick(tab)}
-                                        className="flex items-center justify-between w-full -mx-3 rounded-lg px-3 py-3 text-lg font-semibold text-gray-900 hover:bg-gray-50 hover:text-green-600 transition-colors"
-                                    >
-                                        {tab.name}
-                                        <ChevronDownIcon className="size-5 -rotate-90" />
-                                    </button>
-                                ))}
-                            </div>
-
-                            <div className="py-6">
-                                <button
-                                    onClick={async () => {
-                                        setMobileMenuOpen(false);
-                                        await signOut({
-                                            redirect: true,
-                                            callbackUrl: "/",
-                                        });
-                                    }}
-                                    className="-mx-3 block rounded-lg px-3 py-3 text-lg font-semibold hover:text-green-600 text-gray-900 hover:bg-gray-50 transition-colors"
-                                >
-                                    Sign Out
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </DialogPanel>
-            </Dialog>
-
-            {/* Mobile Modal for Dropdown Content */}
-            <Dialog
-                open={mobileModalOpen}
-                onClose={handleMobileModalClose}
-                className="lg:hidden"
-            >
-                <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
-                <DialogPanel className="fixed inset-0 z-50 overflow-y-auto bg-white">
-                    <div className="min-h-full px-6 py-6">
-                        <div className="flex items-center justify-between mb-6">
-                            <h2 className="text-2xl font-bold text-green-700 ">
-                                {mobileModalContent?.name}
-                            </h2>
-                            <button
-                                type="button"
-                                onClick={handleMobileModalClose}
-                                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
-                            >
-                                <span className="sr-only">Back to menu</span>
-                                <XMarkIcon aria-hidden="true" className="size-6" />
-                            </button>
-                        </div>
-
-                        <div className="space-y-1">
-                            {mobileModalContent?.items.map((item) => (
-                                <Link
-                                    key={item.name}
-                                    href={item.href}
-                                    onClick={() => {
-                                        setMobileModalOpen(false);
-                                        setMobileModalContent(null);
-                                    }}
-                                    className="group block rounded-lg px-4 py-4 hover:bg-gray-50 transition-colors"
-                                >
-                                    <div className="font-medium text-gray-900 group-hover:text-green-600 text-lg">{item.name}</div>
-                                    {item.description && (
-                                        <div className="text-sm text-gray-500 mt-1">{item.description}</div>
-                                    )}
-                                </Link>
-                            ))}
-                        </div>
-                    </div>
-                </DialogPanel>
-            </Dialog>
-        </>
-    );
+                  )}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </DialogPanel>
+      </Dialog>
+    </>
+  );
 };

--- a/src/components/AuthenticatedHeader.tsx
+++ b/src/components/AuthenticatedHeader.tsx
@@ -1,0 +1,282 @@
+"use client";
+import {FC, useEffect, useRef, useState} from "react";
+import Link from "next/link";
+import {signOut, useSession} from "next-auth/react";
+import {Dialog, DialogPanel} from "@headlessui/react";
+import {Bars3Icon, ChevronDownIcon, XMarkIcon} from "@heroicons/react/24/outline";
+
+interface DropdownItem {
+    name: string;
+    href: string;
+    description?: string;
+}
+
+interface NavigationTab {
+    name: string;
+    items: DropdownItem[];
+}
+
+export const AuthenticatedHeader: FC<{
+    dataTestId: string;
+}> = ({ dataTestId }) => {
+    const [mobileMenuOpen, setMobileMenuOpen] = useState<boolean>(false);
+    const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
+    const [mobileModalOpen, setMobileModalOpen] = useState<boolean>(false);
+    const [mobileModalContent, setMobileModalContent] = useState<NavigationTab | null>(null);
+    const { data: session } = useSession();
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    // Navigation structure
+    const navigationTabs: NavigationTab[] = [
+        {
+            name: "Customers",
+            items: [
+                { name: "Customer List", href: "/customers", description: "View all customers" },
+                { name: "Add Customer", href: "/customers/add", description: "Create new customer" },
+                { name: "Customer Groups", href: "/customers/groups", description: "Manage customer segments" },
+                { name: "Customer Reports", href: "/customers/reports", description: "Customer analytics" },
+            ],
+        },
+        {
+            name: "Banking",
+            items: [
+                { name: "Accounts", href: "/banking/accounts", description: "Bank account management" },
+                { name: "Transactions", href: "/banking/transactions", description: "Transaction history" },
+                { name: "Reconciliation", href: "/banking/reconciliation", description: "Bank reconciliation" },
+                { name: "Transfers", href: "/banking/transfers", description: "Money transfers" },
+            ],
+        },
+        {
+            name: "Accounting",
+            items: [
+                { name: "Chart of Accounts", href: "/accounting/chart", description: "Account structure" },
+                { name: "Journal Entries", href: "/accounting/journal", description: "Manual entries" },
+                { name: "General Ledger", href: "/accounting/ledger", description: "Account balances" },
+                { name: "Trial Balance", href: "/accounting/trial-balance", description: "Balance verification" },
+            ],
+        },
+        {
+            name: "Tools",
+            items: [
+                { name: "Bulk Operations", href: "/tools/bulk", description: "Batch processing" },
+                { name: "Import/Export", href: "/tools/import-export", description: "Data management" },
+                { name: "Integrations", href: "/tools/integrations", description: "Third-party apps" },
+                { name: "Settings", href: "/tools/settings", description: "System configuration" },
+            ],
+        },
+        {
+            name: "Reports",
+            items: [
+                { name: "Financial Reports", href: "/reports/financial", description: "P&L, Balance Sheet" },
+                { name: "Tax Reports", href: "/reports/tax", description: "Tax compliance" },
+                { name: "Custom Reports", href: "/reports/custom", description: "Build your own" },
+                { name: "Scheduled Reports", href: "/reports/scheduled", description: "Automated reporting" },
+            ],
+        },
+    ];
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setActiveDropdown(null);
+            }
+        };
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, []);
+
+    const handleMobileTabClick = (tab: NavigationTab) => {
+        setMobileMenuOpen(false);
+        setMobileModalContent(tab);
+        setMobileModalOpen(true);
+    };
+
+    const handleMobileModalClose = () => {
+        setMobileModalOpen(false);
+        setMobileModalContent(null);
+        setMobileMenuOpen(true);
+    };
+
+    return (
+        <>
+            <header
+                className="sticky inset-x-0 top-0 z-50 bg-white/95 backdrop-blur-sm border-b border-gray-200"
+                data-testid={`header-${dataTestId}`}
+            >
+                <div className="mx-auto max-w-10xl">
+                    <div className="px-6 pt-4 pb-4 lg:max-w-none lg:px-8">
+                        <nav
+                            aria-label="Global"
+                            className="flex items-center justify-between"
+                        >
+                            <Link href="/" className="-m-1.5 p-2">
+                                <span className="sr-only">PayHive</span>
+                                <span className="text-2xl font-bold text-gray-900">PayHive</span>
+                            </Link>
+
+                            <button
+                                type="button"
+                                onClick={() => setMobileMenuOpen(true)}
+                                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors lg:hidden"
+                            >
+                                <span className="sr-only">Open main menu</span>
+                                <Bars3Icon aria-hidden="true" className="size-6" />
+                            </button>
+
+                            <div className="hidden lg:flex lg:gap-x-1 lg:items-center" ref={dropdownRef}>
+                                {navigationTabs.map((tab) => (
+                                    <div key={tab.name} className="relative font-semibold">
+                                        <button
+                                            onClick={() => setActiveDropdown(activeDropdown === tab.name ? null : tab.name)}
+                                            className="flex items-center font-semibold gap-1 text-lg text-gray-700 hover:text-green-600 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
+                                        >
+                                            {tab.name}
+                                            <ChevronDownIcon
+                                                className={`size-4 transition-transform ${
+                                                    activeDropdown === tab.name ? 'rotate-180' : ''
+                                                }`}
+                                            />
+                                        </button>
+
+                                        {activeDropdown === tab.name && (
+                                            <div className="absolute top-full left-0 mt-1 w-72 bg-white rounded-lg shadow-lg border border-gray-200 py-2 z-50">
+                                                {tab.items.map((item) => (
+                                                    <Link
+                                                        key={item.name}
+                                                        href={item.href}
+                                                        onClick={() => setActiveDropdown(null)}
+                                                        className="block px-4 py-3 hover:bg-gray-50 transition-colors"
+                                                    >
+                                                        <div className="font-medium text-gray-900">{item.name}</div>
+                                                        {item.description && (
+                                                            <div className="text-sm text-gray-500 mt-1">{item.description}</div>
+                                                        )}
+                                                    </Link>
+                                                ))}
+                                            </div>
+                                        )}
+                                    </div>
+                                ))}
+
+                                <button
+                                    onClick={async () =>
+                                        await signOut({
+                                            redirect: true,
+                                            callbackUrl: "/",
+                                        })
+                                    }
+                                    className="ml-4 font-semibold text-lg text-gray-700 hover:text-gray-900 px-3 py-2 rounded-md hover:bg-gray-50 transition-colors"
+                                >
+                                    Sign Out
+                                </button>
+                            </div>
+                        </nav>
+                    </div>
+                </div>
+            </header>
+
+            {/* Mobile Menu */}
+            <Dialog
+                open={mobileMenuOpen}
+                onClose={setMobileMenuOpen}
+                className="lg:hidden"
+            >
+                <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
+                <DialogPanel className="fixed inset-y-0 right-0 z-50 w-full overflow-y-auto bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-200 shadow-xl">
+                    <div className="flex items-center justify-between">
+                        <Link href="/" className="-m-1.5 py-1.5 pr-1.5">
+                            <span className="sr-only">PayHive</span>
+                            <span className="text-2xl font-bold text-gray-900">PayHive</span>
+                        </Link>
+                        <button
+                            type="button"
+                            onClick={() => setMobileMenuOpen(false)}
+                            className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                        >
+                            <span className="sr-only">Close menu</span>
+                            <XMarkIcon aria-hidden="true" className="size-6" />
+                        </button>
+                    </div>
+
+                    <div className="mt-6 flow-root">
+                        <div className="-my-6 divide-y divide-gray-200">
+                            <div className="space-y-2 py-6">
+                                {navigationTabs.map((tab) => (
+                                    <button
+                                        key={tab.name}
+                                        onClick={() => handleMobileTabClick(tab)}
+                                        className="flex items-center justify-between w-full -mx-3 rounded-lg px-3 py-3 text-lg font-semibold text-gray-900 hover:bg-gray-50 hover:text-green-600 transition-colors"
+                                    >
+                                        {tab.name}
+                                        <ChevronDownIcon className="size-5 -rotate-90" />
+                                    </button>
+                                ))}
+                            </div>
+
+                            <div className="py-6">
+                                <button
+                                    onClick={async () => {
+                                        setMobileMenuOpen(false);
+                                        await signOut({
+                                            redirect: true,
+                                            callbackUrl: "/",
+                                        });
+                                    }}
+                                    className="-mx-3 block rounded-lg px-3 py-3 text-lg font-semibold hover:text-green-600 text-gray-900 hover:bg-gray-50 transition-colors"
+                                >
+                                    Sign Out
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </DialogPanel>
+            </Dialog>
+
+            {/* Mobile Modal for Dropdown Content */}
+            <Dialog
+                open={mobileModalOpen}
+                onClose={handleMobileModalClose}
+                className="lg:hidden"
+            >
+                <div className="fixed inset-0 z-50 bg-black/20 backdrop-blur-sm" />
+                <DialogPanel className="fixed inset-0 z-50 overflow-y-auto bg-white">
+                    <div className="min-h-full px-6 py-6">
+                        <div className="flex items-center justify-between mb-6">
+                            <h2 className="text-2xl font-bold text-green-700 ">
+                                {mobileModalContent?.name}
+                            </h2>
+                            <button
+                                type="button"
+                                onClick={handleMobileModalClose}
+                                className="-m-2.5 rounded-md p-2.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+                            >
+                                <span className="sr-only">Back to menu</span>
+                                <XMarkIcon aria-hidden="true" className="size-6" />
+                            </button>
+                        </div>
+
+                        <div className="space-y-1">
+                            {mobileModalContent?.items.map((item) => (
+                                <Link
+                                    key={item.name}
+                                    href={item.href}
+                                    onClick={() => {
+                                        setMobileModalOpen(false);
+                                        setMobileModalContent(null);
+                                    }}
+                                    className="group block rounded-lg px-4 py-4 hover:bg-gray-50 transition-colors"
+                                >
+                                    <div className="font-medium text-gray-900 group-hover:text-green-600 text-lg">{item.name}</div>
+                                    {item.description && (
+                                        <div className="text-sm text-gray-500 mt-1">{item.description}</div>
+                                    )}
+                                </Link>
+                            ))}
+                        </div>
+                    </div>
+                </DialogPanel>
+            </Dialog>
+        </>
+    );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,11 @@
 "use client";
-import {FC, useState} from "react";
+import { FC, useState } from "react";
 import Link from "next/link";
-import {signOut, useSession} from "next-auth/react";
-import {Dialog, DialogPanel} from "@headlessui/react";
-import {Bars3Icon, XMarkIcon} from "@heroicons/react/24/outline";
-import {toKebabCase} from "@/utils";
-import {useSelectedPath} from "@/hooks";
+import { signOut, useSession } from "next-auth/react";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
+import { toKebabCase } from "@/utils";
+import { useSelectedPath } from "@/hooks";
 
 export const Header: FC<{
   tabs: Array<{ name: string; href: string }>;
@@ -30,7 +30,7 @@ export const Header: FC<{
       toKebabCase(tab.name) as keyof typeof selectedPath
     ]
       ? "transparent"
-      : mobileLinkHoveredTab === tab.name && "f9fafb",
+      : (mobileLinkHoveredTab === tab.name && "f9fafb").toString(),
     color: selectedPath[toKebabCase(tab.name) as keyof typeof selectedPath]
       ? "#15803d"
       : mobileLinkHoveredTab === tab.name

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,11 @@
 "use client";
-import { FC, useState } from "react";
+import {FC, useState} from "react";
 import Link from "next/link";
-import { signOut, useSession } from "next-auth/react";
-import { Dialog, DialogPanel } from "@headlessui/react";
-import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
-import { toKebabCase } from "@/utils";
-import { useSelectedPath } from "@/hooks";
+import {signOut, useSession} from "next-auth/react";
+import {Dialog, DialogPanel} from "@headlessui/react";
+import {Bars3Icon, XMarkIcon} from "@heroicons/react/24/outline";
+import {toKebabCase} from "@/utils";
+import {useSelectedPath} from "@/hooks";
 
 export const Header: FC<{
   tabs: Array<{ name: string; href: string }>;
@@ -21,22 +21,20 @@ export const Header: FC<{
   const selectedPathClassName = `text-green-700 border-b-2 border-green-700 font-semibold`;
   const nonSelectedPathClassName =
     "text-gray-600 hover:text-green-700 hover:border-b-2 hover:border-green-300 font-semibold transition-colors";
-  const selectedPathMobileClassName = "bg-green-100 text-green-900";
+  const selectedPathMobileClassName = "text-green-700";
   const nonSelectedPathMobileClassName =
-    "text-gray-900 hover:bg-green-50 hover:text-green-700 transition-colors";
+    "text-gray-900 hover:bg-gray-50 hover:text-green-600 transition-colors";
 
   const getMobileTabStyle = (tab: Record<string, string>) => ({
     backgroundColor: selectedPath[
       toKebabCase(tab.name) as keyof typeof selectedPath
     ]
-      ? "#dcfce7"
-      : mobileLinkHoveredTab === tab.name
-        ? "#f0fdf4"
-        : "transparent",
+      ? "transparent"
+      : mobileLinkHoveredTab === tab.name && "f9fafb",
     color: selectedPath[toKebabCase(tab.name) as keyof typeof selectedPath]
-      ? "#14532d"
+      ? "#15803d"
       : mobileLinkHoveredTab === tab.name
-        ? "#15803d"
+        ? "#16a34a"
         : "#111827",
   });
 
@@ -102,7 +100,7 @@ export const Header: FC<{
 
                   <Link
                     href="/sign-up"
-                    className="cursor-pointer bg-green-700 hover:bg-green-800 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
+                    className="cursor-pointer hover:bg-gray-50 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
                   >
                     Start Free Trial
                   </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -100,7 +100,7 @@ export const Header: FC<{
 
                   <Link
                     href="/sign-up"
-                    className="cursor-pointer hover:bg-gray-50 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
+                    className="cursor-pointer hover:bg-green-800 bg-green-700 text-white px-6 py-2 rounded-lg font-semibold transition-colors"
                   >
                     Start Free Trial
                   </Link>

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,48 @@
+import { Dots } from "@/icons";
+
+export const metadata = {
+  title: "Loading - Calculating...",
+};
+
+export default function Loading() {
+  return (
+    <main className="relative my-56 w-full">
+      <div className="absolute inset-0 z-0 overflow-hidden">
+        <Dots className="mx-auto opacity-30" />
+      </div>
+      <div className="text-center relative z-10 flex flex-col justify-center items-center space-y-10 px-8 md:px-2">
+        <div className="relative">
+          <div className="w-24 h-24 border-8 border-gray-200 border-t-lime-600 rounded-full animate-spin"></div>
+          <div className="absolute inset-0 flex items-center justify-center">
+            <span className="text-2xl font-bold text-lime-600">£££</span>
+          </div>
+        </div>
+
+        <h2 className="text-xl md:text-3xl font-semibold text-gray-700 pt-8 mb-6">
+          Balancing the books...
+        </h2>
+
+        <div className="text-lg md:text-xl text-gray-600 flex flex-col items-center justify-center">
+          <span>Our busy bees are crunching the numbers for you.</span>
+          <span>This calculation won't take long!</span>
+        </div>
+
+        <p className="text-baseline md:text-lg text-gray-500 italic mb-8">
+          Status: PROCESSING_LEDGER_001
+        </p>
+
+        <div className="flex space-x-2">
+          <div className="w-3 h-3 bg-lime-600 rounded-full animate-pulse"></div>
+          <div
+            className="w-3 h-3 bg-lime-600 rounded-full animate-pulse"
+            style={{ animationDelay: "0.2s" }}
+          ></div>
+          <div
+            className="w-3 h-3 bg-lime-600 rounded-full animate-pulse"
+            style={{ animationDelay: "0.4s" }}
+          ></div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,5 @@
 export { Header } from "./Header";
 export { Footer } from "./Footer";
 export { ContactNotificationEmail } from "./ContactNotificationEmail";
+export { AuthenticatedHeader } from "./AuthenticatedHeader";
+export { AuthWrapper } from "./AuthWrapper";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 export { TABS } from "./tabs";
 export { FEATURES } from "./features";
 export { FAQS } from "./faqs";
+export { PROTECTED_ROUTES } from "./protectedRoutes";

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,3 +2,4 @@ export { TABS } from "./tabs";
 export { FEATURES } from "./features";
 export { FAQS } from "./faqs";
 export { PROTECTED_ROUTES } from "./protectedRoutes";
+export { NAVIGATION_TABS } from "./navigationTabs";

--- a/src/constants/navigationTabs.ts
+++ b/src/constants/navigationTabs.ts
@@ -1,0 +1,129 @@
+import { NavigationTab } from "@/types";
+
+export const NAVIGATION_TABS: NavigationTab[] = [
+  {
+    name: "Customers",
+    items: [
+      {
+        name: "Customer List",
+        href: "/customers",
+        description: "View all customers",
+      },
+      {
+        name: "Add Customer",
+        href: "/customers/add",
+        description: "Create new customer",
+      },
+      {
+        name: "Customer Groups",
+        href: "/customers/groups",
+        description: "Manage customer segments",
+      },
+      {
+        name: "Customer Reports",
+        href: "/customers/reports",
+        description: "Customer analytics",
+      },
+    ],
+  },
+  {
+    name: "Banking",
+    items: [
+      {
+        name: "Accounts",
+        href: "/banking/accounts",
+        description: "Bank account management",
+      },
+      {
+        name: "Transactions",
+        href: "/banking/transactions",
+        description: "Transaction history",
+      },
+      {
+        name: "Reconciliation",
+        href: "/banking/reconciliation",
+        description: "Bank reconciliation",
+      },
+      {
+        name: "Transfers",
+        href: "/banking/transfers",
+        description: "Money transfers",
+      },
+    ],
+  },
+  {
+    name: "Accounting",
+    items: [
+      {
+        name: "Chart of Accounts",
+        href: "/accounting/chart",
+        description: "Account structure",
+      },
+      {
+        name: "Journal Entries",
+        href: "/accounting/journal",
+        description: "Manual entries",
+      },
+      {
+        name: "General Ledger",
+        href: "/accounting/ledger",
+        description: "Account balances",
+      },
+      {
+        name: "Trial Balance",
+        href: "/accounting/trial-balance",
+        description: "Balance verification",
+      },
+    ],
+  },
+  {
+    name: "Tools",
+    items: [
+      {
+        name: "Bulk Operations",
+        href: "/tools/bulk",
+        description: "Batch processing",
+      },
+      {
+        name: "Import/Export",
+        href: "/tools/import-export",
+        description: "Data management",
+      },
+      {
+        name: "Integrations",
+        href: "/tools/integrations",
+        description: "Third-party apps",
+      },
+      {
+        name: "Settings",
+        href: "/tools/settings",
+        description: "System configuration",
+      },
+    ],
+  },
+  {
+    name: "Reports",
+    items: [
+      {
+        name: "Financial Reports",
+        href: "/reports/financial",
+        description: "P&L, Balance Sheet",
+      },
+      {
+        name: "Tax Reports",
+        href: "/reports/tax",
+        description: "Tax compliance",
+      },
+      {
+        name: "Custom Reports",
+        href: "/reports/custom",
+        description: "Build your own",
+      },
+      {
+        name: "Scheduled Reports",
+        href: "/reports/scheduled",
+        description: "Automated reporting",
+      },
+    ],
+  },
+];

--- a/src/constants/protectedRoutes.ts
+++ b/src/constants/protectedRoutes.ts
@@ -1,0 +1,10 @@
+export const PROTECTED_ROUTES = [
+  "/profile",
+  "/dashboard",
+  "/customers",
+  "/banking",
+  "/accounting",
+  "/tools",
+  "/reports",
+  "/settings",
+];

--- a/src/types/AuthWrapperProps.ts
+++ b/src/types/AuthWrapperProps.ts
@@ -1,0 +1,8 @@
+import { ReactNode } from "react";
+
+export type AuthWrapperProps = {
+  children: ReactNode;
+  requireAuth?: boolean;
+  requireSubscription?: boolean;
+  redirectTo?: string;
+};

--- a/src/types/NavigationTab.ts
+++ b/src/types/NavigationTab.ts
@@ -1,0 +1,10 @@
+type DropdownItem = {
+  name: string;
+  href: string;
+  description?: string;
+};
+
+export type NavigationTab = {
+  name: string;
+  items: DropdownItem[];
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,4 @@
 export type { SelectedPath } from "./SelectedPath";
 export type { ContactFormData } from "./ContactFormData";
+export type { NavigationTab } from "./NavigationTab";
+export type { AuthWrapperProps } from "./AuthWrapperProps";

--- a/test/integration/AuthenticatedHeader.test.tsx
+++ b/test/integration/AuthenticatedHeader.test.tsx
@@ -1,0 +1,695 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AuthenticatedHeader } from "@/components";
+
+global.fetch = jest.fn();
+
+const TestWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return <div>{children}</div>;
+};
+
+const renderWithWrapper = (component: React.ReactElement) => {
+  return render(component, { wrapper: TestWrapper });
+};
+
+describe("AuthenticatedHeader", () => {
+  beforeEach(() => {
+    document.removeEventListener = jest.fn();
+    document.addEventListener = jest.fn();
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("Basic Rendering", () => {
+    test("renders the header with correct structure", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const header = screen.getByTestId("header-test");
+      expect(header).toBeInTheDocument();
+      expect(header).toHaveClass("sticky", "inset-x-0", "top-0", "z-50");
+    });
+
+    test("renders PayHive logo as link", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const nav = screen.getByRole("navigation", { name: "Global" });
+      const logoText = nav.querySelector(".text-2xl.font-bold.text-gray-900");
+      expect(logoText).toBeInTheDocument();
+      expect(logoText).toHaveTextContent("PayHive");
+
+      const logoLink = logoText?.closest("a");
+      expect(logoLink).toHaveAttribute("href", "/");
+    });
+
+    test("renders mobile menu toggle button", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      expect(mobileMenuButton).toBeInTheDocument();
+      expect(mobileMenuButton).toHaveClass("lg:hidden");
+    });
+
+    test("renders desktop navigation area", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const nav = screen.getByRole("navigation", { name: "Global" });
+      const desktopNav = nav.querySelector(".hidden.lg\\:flex");
+      expect(desktopNav).toBeInTheDocument();
+    });
+  });
+
+  describe("State Management", () => {
+    test("initializes with mobile menu closed", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("opens mobile menu when button is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+
+    test("closes mobile menu when close button is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const closeButton = screen.getByRole("button", { name: /close menu/i });
+      await user.click(closeButton);
+
+      await waitFor(() => {
+        expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Desktop Dropdown Behavior", () => {
+    test("opens and closes dropdowns correctly", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const dropdownButtons = Array.from(
+          desktopNav.querySelectorAll("button"),
+        ).filter(
+          (button) =>
+            button.querySelector("svg") &&
+            !button.textContent?.includes("Sign Out"),
+        );
+
+        if (dropdownButtons.length > 0) {
+          const firstDropdownButton = dropdownButtons[0];
+          const tabName = firstDropdownButton.textContent?.trim();
+
+          await user.click(firstDropdownButton);
+
+          const chevron = firstDropdownButton.querySelector("svg");
+          if (chevron) {
+            expect(chevron).toHaveClass("rotate-180");
+          }
+
+          await user.click(firstDropdownButton);
+
+          if (chevron) {
+            expect(chevron).not.toHaveClass("rotate-180");
+          }
+        }
+      }
+    });
+
+    test("switches between different dropdowns", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const dropdownButtons = Array.from(
+          desktopNav.querySelectorAll("button"),
+        ).filter(
+          (button) =>
+            button.querySelector("svg") &&
+            !button.textContent?.includes("Sign Out"),
+        );
+
+        if (dropdownButtons.length >= 2) {
+          await user.click(dropdownButtons[0]);
+          await user.click(dropdownButtons[1]);
+
+          const firstChevron = dropdownButtons[0].querySelector("svg");
+          const secondChevron = dropdownButtons[1].querySelector("svg");
+
+          if (firstChevron) {
+            expect(firstChevron).not.toHaveClass("rotate-180");
+          }
+          if (secondChevron) {
+            expect(secondChevron).toHaveClass("rotate-180");
+          }
+        }
+      }
+    });
+
+    test("closes dropdown when clicking dropdown item", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const dropdownButtons = Array.from(
+          desktopNav.querySelectorAll("button"),
+        ).filter(
+          (button) =>
+            button.querySelector("svg") &&
+            !button.textContent?.includes("Sign Out"),
+        );
+
+        if (dropdownButtons.length > 0) {
+          await user.click(dropdownButtons[0]);
+
+          const dropdownContent =
+            desktopNav.querySelector(".absolute.top-full");
+          if (dropdownContent) {
+            const dropdownLink = dropdownContent.querySelector("a");
+            if (dropdownLink) {
+              await user.click(dropdownLink);
+
+              const chevron = dropdownButtons[0].querySelector("svg");
+              if (chevron) {
+                expect(chevron).not.toHaveClass("rotate-180");
+              }
+            }
+          }
+        }
+      }
+    });
+
+    test("handles outside click events", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      expect(document.addEventListener).toHaveBeenCalledWith(
+        "mousedown",
+        expect.any(Function),
+      );
+    });
+
+    test("closes dropdown when clicking outside or switching dropdowns", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const dropdownButtons = Array.from(
+          desktopNav.querySelectorAll("button"),
+        ).filter(
+          (button) =>
+            button.querySelector("svg") &&
+            !button.textContent?.includes("Sign Out"),
+        );
+
+        if (dropdownButtons.length >= 2) {
+          const firstButton = dropdownButtons[0];
+          const secondButton = dropdownButtons[1];
+
+          await user.click(firstButton);
+
+          const firstChevron = firstButton.querySelector("svg");
+          if (firstChevron) {
+            expect(firstChevron).toHaveClass("rotate-180");
+
+            await user.click(secondButton);
+
+            await waitFor(
+              () => {
+                expect(firstChevron).not.toHaveClass("rotate-180");
+              },
+              { timeout: 1000 },
+            );
+          }
+        } else if (dropdownButtons.length === 1) {
+          const dropdownButton = dropdownButtons[0];
+
+          await user.click(dropdownButton);
+
+          const chevron = dropdownButton.querySelector("svg");
+          if (chevron) {
+            expect(chevron).toHaveClass("rotate-180");
+
+            await user.click(dropdownButton);
+
+            await waitFor(
+              () => {
+                expect(chevron).not.toHaveClass("rotate-180");
+              },
+              { timeout: 1000 },
+            );
+          }
+        }
+      }
+    });
+
+    test("does not close dropdown when clicking inside dropdown ref", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const dropdownButtons = Array.from(
+          desktopNav.querySelectorAll("button"),
+        ).filter(
+          (button) =>
+            button.querySelector("svg") &&
+            !button.textContent?.includes("Sign Out"),
+        );
+
+        if (dropdownButtons.length > 0) {
+          const dropdownButton = dropdownButtons[0];
+          await user.click(dropdownButton);
+
+          const chevron = dropdownButton.querySelector("svg");
+          if (chevron) {
+            expect(chevron).toHaveClass("rotate-180");
+
+            fireEvent.mouseDown(dropdownButton);
+
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            expect(chevron).toHaveClass("rotate-180");
+          }
+        }
+      }
+    });
+
+    test("cleans up event listeners on unmount", () => {
+      const { unmount } = renderWithWrapper(
+        <AuthenticatedHeader dataTestId="test" />,
+      );
+
+      unmount();
+
+      expect(document.removeEventListener).toHaveBeenCalledWith(
+        "mousedown",
+        expect.any(Function),
+      );
+    });
+  });
+
+  describe("Mobile Navigation Flow", () => {
+    test("handles mobile tab click flow", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const mobileNavButtons = screen
+        .getAllByRole("button")
+        .filter((button) => {
+          const ariaLabel = button.getAttribute("aria-label");
+          return (
+            !ariaLabel?.includes("Close") &&
+            !ariaLabel?.includes("Open") &&
+            button.textContent !== "Sign Out" &&
+            button.querySelector('svg[class*="rotate-90"]')
+          );
+        });
+
+      if (mobileNavButtons.length > 0) {
+        const firstNavButton = mobileNavButtons[0];
+        await user.click(firstNavButton);
+
+        await waitFor(() => {
+          expect(screen.queryByRole("dialog")).toBeInTheDocument();
+        });
+      }
+    });
+
+    test("handles mobile modal close and returns to menu", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const mobileNavButtons = screen
+        .getAllByRole("button")
+        .filter((button) => {
+          const ariaLabel = button.getAttribute("aria-label");
+          return (
+            !ariaLabel?.includes("Close") &&
+            !ariaLabel?.includes("Open") &&
+            button.textContent !== "Sign Out" &&
+            button.querySelector("svg")
+          );
+        });
+
+      if (mobileNavButtons.length > 0) {
+        await user.click(mobileNavButtons[0]);
+
+        const backButton = screen.queryByRole("button", {
+          name: /back to menu/i,
+        });
+        if (backButton) {
+          await user.click(backButton);
+
+          await waitFor(() => {
+            const dialogs = screen.getAllByRole("dialog");
+            expect(dialogs.length).toBeGreaterThan(0);
+          });
+        }
+      }
+    });
+
+    test("handles mobile modal item click", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const mobileNavButtons = screen
+        .getAllByRole("button")
+        .filter((button) => {
+          return (
+            button.textContent !== "Sign Out" &&
+            button.querySelector("svg") &&
+            !button.getAttribute("aria-label")?.includes("Close")
+          );
+        });
+
+      if (mobileNavButtons.length > 0) {
+        await user.click(mobileNavButtons[0]);
+
+        const modalLinks = screen
+          .getAllByRole("link")
+          .filter((link) => link.closest('[role="dialog"]'));
+
+        if (modalLinks.length > 0) {
+          await user.click(modalLinks[0]);
+        }
+      }
+    });
+
+    test("closes mobile menu and modal when link is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const mobileNavButtons = screen
+        .getAllByRole("button")
+        .filter(
+          (button) =>
+            button.textContent !== "Sign Out" &&
+            button.querySelector("svg") &&
+            !button.getAttribute("aria-label")?.includes("menu"),
+        );
+
+      if (mobileNavButtons.length > 0) {
+        await user.click(mobileNavButtons[0]);
+      }
+    });
+  });
+
+  describe("Sign Out Functionality", () => {
+    test("renders sign out button in desktop view", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const signOutButtons = screen.getAllByText("Sign Out");
+      expect(signOutButtons.length).toBeGreaterThan(0);
+
+      const desktopSignOutButton = signOutButtons.find((button) =>
+        button.closest(".hidden.lg\\:flex"),
+      );
+
+      if (desktopSignOutButton) {
+        expect(desktopSignOutButton).toHaveClass("font-semibold", "text-lg");
+      }
+    });
+
+    test("renders sign out button in mobile menu", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const signOutButtons = screen.getAllByText("Sign Out");
+      expect(signOutButtons.length).toBeGreaterThan(0);
+    });
+
+    test("calls signOut with correct parameters when desktop button clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const desktopNav = screen
+        .getByRole("navigation")
+        .querySelector(".hidden.lg\\:flex");
+      if (desktopNav) {
+        const signOutButton = desktopNav.querySelector("button:last-child");
+        if (signOutButton && signOutButton.textContent === "Sign Out") {
+          await user.click(signOutButton);
+        }
+      }
+    });
+
+    test("calls signOut when mobile sign out button clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const dialog = screen.getByRole("dialog");
+      const mobileSignOutButton = dialog.querySelector("button:last-child");
+      if (
+        mobileSignOutButton &&
+        mobileSignOutButton.textContent === "Sign Out"
+      ) {
+        await user.click(mobileSignOutButton);
+      }
+    });
+
+    test("closes mobile menu when sign out is clicked", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+      const signOutButtons = screen.getAllByRole("button", {
+        name: /sign out/i,
+      });
+      const mobileSignOutButton = signOutButtons.find((button) =>
+        button.closest('[role="dialog"]'),
+      );
+
+      if (mobileSignOutButton) {
+        await user.click(mobileSignOutButton);
+
+        await waitFor(
+          () => {
+            expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+          },
+          { timeout: 1000 },
+        );
+      }
+    });
+
+    test("sign out button has correct styling and behavior setup", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const signOutButtons = screen.getAllByRole("button", {
+        name: /sign out/i,
+      });
+
+      signOutButtons.forEach((button) => {
+        expect(button).toHaveClass("transition-colors");
+        expect(button.tagName).toBe("BUTTON");
+      });
+    });
+  });
+
+  describe("Responsive Design", () => {
+    test("has correct responsive classes for mobile menu", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      expect(mobileMenuButton).toHaveClass("lg:hidden");
+    });
+
+    test("has correct responsive classes for desktop navigation", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const nav = screen.getByRole("navigation");
+      const desktopNav = nav.querySelector(".hidden.lg\\:flex");
+      expect(desktopNav).toBeInTheDocument();
+    });
+
+    test("header has sticky positioning and backdrop blur", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const header = screen.getByTestId("header-test");
+      expect(header).toHaveClass(
+        "sticky",
+        "inset-x-0",
+        "top-0",
+        "z-50",
+        "bg-white/95",
+        "backdrop-blur-sm",
+      );
+    });
+  });
+
+  describe("Accessibility", () => {
+    test("has proper ARIA labels", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const nav = screen.getByRole("navigation");
+      expect(nav).toHaveAttribute("aria-label", "Global");
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      expect(mobileMenuButton).toBeInTheDocument();
+    });
+
+    test("has proper screen reader text", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const srText = screen.getByText("PayHive", { selector: ".sr-only" });
+      expect(srText).toBeInTheDocument();
+      expect(srText).toHaveClass("sr-only");
+    });
+
+    test("mobile menu close button has proper accessibility", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const closeButton = screen.getByRole("button", { name: /close menu/i });
+      expect(closeButton).toBeInTheDocument();
+    });
+  });
+
+  describe("Visual States and Transitions", () => {
+    test("applies hover states correctly", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      expect(mobileMenuButton).toHaveClass("transition-colors");
+
+      const signOutButtons = screen.getAllByRole("button", {
+        name: /sign out/i,
+      });
+      signOutButtons.forEach((button) => {
+        expect(button).toHaveClass("transition-colors");
+      });
+    });
+
+    test("has proper z-index layering", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const header = screen.getByTestId("header-test");
+      expect(header).toHaveClass("z-50");
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+      await user.click(mobileMenuButton);
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog.querySelector(".fixed")).toHaveClass("z-50");
+    });
+
+    test("handles focus management", async () => {
+      const user = userEvent.setup();
+      renderWithWrapper(<AuthenticatedHeader dataTestId="test" />);
+
+      const mobileMenuButton = screen.getByRole("button", {
+        name: /open main menu/i,
+      });
+
+      await user.click(mobileMenuButton);
+
+      const dialog = screen.getByRole("dialog");
+      expect(dialog).toBeInTheDocument();
+    });
+  });
+
+  describe("Component Props", () => {
+    test("accepts and uses dataTestId prop correctly", () => {
+      renderWithWrapper(<AuthenticatedHeader dataTestId="custom-test-id" />);
+
+      expect(screen.getByTestId("header-custom-test-id")).toBeInTheDocument();
+    });
+
+    test("works with different dataTestId values", () => {
+      const { rerender } = renderWithWrapper(
+        <AuthenticatedHeader dataTestId="first" />,
+      );
+      expect(screen.getByTestId("header-first")).toBeInTheDocument();
+
+      rerender(<AuthenticatedHeader dataTestId="second" />);
+      expect(screen.getByTestId("header-second")).toBeInTheDocument();
+      expect(screen.queryByTestId("header-first")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/test/integration/Header.test.tsx
+++ b/test/integration/Header.test.tsx
@@ -331,19 +331,16 @@ describe("Header Component", () => {
 
       if (mobileHomeLink) {
         expect(mobileHomeLink).toHaveStyle({
-          backgroundColor: "transparent",
           color: "#111827",
         });
 
         await user.hover(mobileHomeLink);
         expect(mobileHomeLink).toHaveStyle({
-          backgroundColor: "#f0fdf4",
-          color: "#15803d",
+          color: "#16a34a",
         });
 
         await user.unhover(mobileHomeLink);
         expect(mobileHomeLink).toHaveStyle({
-          backgroundColor: "transparent",
           color: "#111827",
         });
       }
@@ -370,8 +367,7 @@ describe("Header Component", () => {
       );
 
       expect(mobileHomeLink).toHaveStyle({
-        backgroundColor: "#dcfce7",
-        color: "#14532d",
+        color: "#15803d",
       });
     });
 
@@ -398,8 +394,7 @@ describe("Header Component", () => {
       if (mobileHomeLink) {
         await user.hover(mobileHomeLink);
         expect(mobileHomeLink).toHaveStyle({
-          backgroundColor: "#dcfce7",
-          color: "#14532d",
+          color: "#15803d",
         });
       }
     });
@@ -618,40 +613,6 @@ describe("Header Component", () => {
 
       await user.click(menuButton);
       expect(screen.getByTestId("dialog")).toBeInTheDocument();
-    });
-
-    test("manages hover state for mobile links independently", async () => {
-      const user = userEvent.setup();
-      renderWithProviders(<Header {...defaultProps} />);
-
-      const menuButton = screen.getByRole("button", {
-        name: /open main menu/i,
-      });
-      await user.click(menuButton);
-
-      const allHomeLinks = screen.getAllByRole("link", { name: "Home" });
-      const allAboutLinks = screen.getAllByRole("link", { name: "About Us" });
-
-      const mobileHomeLink = allHomeLinks.find(
-        (link) =>
-          link.className.includes("block") &&
-          link.className.includes("rounded-lg"),
-      );
-      const mobileAboutLink = allAboutLinks.find(
-        (link) =>
-          link.className.includes("block") &&
-          link.className.includes("rounded-lg"),
-      );
-
-      if (mobileHomeLink && mobileAboutLink) {
-        await user.hover(mobileHomeLink);
-        expect(mobileHomeLink).toHaveStyle({ backgroundColor: "#f0fdf4" });
-        expect(mobileAboutLink).toHaveStyle({ backgroundColor: "transparent" });
-
-        await user.hover(mobileAboutLink);
-        expect(mobileHomeLink).toHaveStyle({ backgroundColor: "transparent" });
-        expect(mobileAboutLink).toHaveStyle({ backgroundColor: "#f0fdf4" });
-      }
     });
 
     test("calls useSelectedPath hook exactly once", () => {


### PR DESCRIPTION
# Changes

- Create authenticated header
- Create nested modal for the mobile version
- Align colours between authenticated and public headers
- Create AuthWrapper and link it with the status of the authentication
- Conditionally render the headers based on the user session
- Update the navigation options
- Fix public header unit tests
- Improve the AuthenticatedHeader coverage
